### PR TITLE
feat(server): add Supabase L2 cache layer for TMDB data

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,11 @@
       "Read(//tmp/**)",
       "Bash(curl -s -o /tmp/timeline.json -w \"HTTP %{http_code}\\\\n\" \"http://localhost:4000/people/135651/timeline\")",
       "Bash(curl -s \"http://localhost:4000/people/135651\")",
-      "Bash(git rm *)"
+      "Bash(git rm *)",
+      "Bash(npx prisma *)",
+      "Bash(npm --prefix server run generate)",
+      "Bash(grep -oE '\"\\\\/movies\\\\/[^\"]+\"' client/app/movies/page.tsx)",
+      "Bash(grep -oE '\"\\\\/tv\\\\/[^\"]+\"' client/app/tv/page.tsx)"
     ]
   }
 }

--- a/server/prisma/migrations/20260602041337_add_media_l2_cache/migration.sql
+++ b/server/prisma/migrations/20260602041337_add_media_l2_cache/migration.sql
@@ -1,0 +1,58 @@
+-- CreateTable
+CREATE TABLE "media_details" (
+    "id" TEXT NOT NULL,
+    "tmdbId" INTEGER NOT NULL,
+    "mediaType" "MediaType" NOT NULL,
+    "title" TEXT NOT NULL,
+    "popularity" DOUBLE PRECISION,
+    "payload" JSONB NOT NULL,
+    "fetchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "media_details_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tv_season_bundles" (
+    "id" TEXT NOT NULL,
+    "tmdbId" INTEGER NOT NULL,
+    "payload" JSONB NOT NULL,
+    "fetchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tv_season_bundles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "recommendation_cache" (
+    "id" TEXT NOT NULL,
+    "tmdbId" INTEGER NOT NULL,
+    "mediaType" "MediaType" NOT NULL,
+    "limit" INTEGER NOT NULL,
+    "payload" JSONB NOT NULL,
+    "fetchedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "recommendation_cache_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "media_details_fetchedAt_idx" ON "media_details"("fetchedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "media_details_tmdbId_mediaType_key" ON "media_details"("tmdbId", "mediaType");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tv_season_bundles_tmdbId_key" ON "tv_season_bundles"("tmdbId");
+
+-- CreateIndex
+CREATE INDEX "tv_season_bundles_fetchedAt_idx" ON "tv_season_bundles"("fetchedAt");
+
+-- CreateIndex
+CREATE INDEX "recommendation_cache_fetchedAt_idx" ON "recommendation_cache"("fetchedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "recommendation_cache_tmdbId_mediaType_limit_key" ON "recommendation_cache"("tmdbId", "mediaType", "limit");

--- a/server/prisma/migrations/20260602081925_remove_redundant_tables/migration.sql
+++ b/server/prisma/migrations/20260602081925_remove_redundant_tables/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Movie` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Series` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `content_cache` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "Movie";
+
+-- DropTable
+DROP TABLE "Series";
+
+-- DropTable
+DROP TABLE "content_cache";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -81,20 +81,6 @@ model LikedList {
   addedAt  DateTime @default(now())
 }
 
-model Series {
-  id          String   @id @default(uuid())
-  tmdbId      String   @unique
-  title       String
-  overview    String
-  posterUrl   String?
-  backdropUrl String?
-  releaseDate String?
-  genres      String[] @default([])
-  rating      Float?
-  moodTags    String[] @default([])
-  createdAt   DateTime @default(now())
-}
-
 model Review {
   id            String        @id @default(uuid())
   userId        String
@@ -131,20 +117,6 @@ model ReviewReply {
 
   @@index([reviewId])
   @@map("review_replies")
-}
-
-model Movie {
-  id          String   @id @default(uuid())
-  tmdbId      String   @unique
-  title       String
-  overview    String
-  posterUrl   String?
-  backdropUrl String?
-  releaseDate String?
-  genres      String[] @default([])
-  rating      Float?
-  moodTags    String[] @default([])
-  createdAt   DateTime @default(now())
 }
 
 model Mood {
@@ -239,32 +211,52 @@ model UserPreference {
   @@map("user_preferences")
 }
 
-model ContentCache {
-  id               String    @id @default(uuid())
-  tmdbId           Int
-  mediaType        MediaType
-  title            String
-  overview         String?
-  genreIds         Int[]
-  voteAverage      Decimal   @db.Decimal(3, 2)
-  voteCount        Int
-  releaseDate      String?
-  posterPath       String?
-  backdropPath     String?
-  popularity       Decimal   @db.Decimal(8, 3)
-  adult            Boolean   @default(false)
-  originalLanguage String
-  metadata         Json?
-  lastFetched      DateTime  @default(now())
-  createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
+// ─── L2 cache (Supabase) for TMDB-derived data ────────────────────────────
+// These store the fully-assembled service responses as JSON so they survive
+// Redis eviction. Redis stays the hot L1; Postgres is the permanent source of
+// truth, refreshed via the fetchedAt staleness check.
+
+model MediaDetail {
+  id         String    @id @default(uuid())
+  tmdbId     Int
+  mediaType  MediaType
+  title      String
+  popularity Float?
+  payload    Json // full movieDetails()/tvDetails() output: { info, credits, trailer, providers }
+  fetchedAt  DateTime  @default(now())
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
 
   @@unique([tmdbId, mediaType])
-  @@index([genreIds])
-  @@index([voteAverage])
-  @@index([popularity])
-  @@index([lastFetched])
-  @@map("content_cache")
+  @@index([fetchedAt])
+  @@map("media_details")
+}
+
+model TvSeasonBundle {
+  id        String   @id @default(uuid())
+  tmdbId    Int      @unique
+  payload   Json // fetchSeasonsWithEpisodes() output: seasons[] with episodes
+  fetchedAt DateTime @default(now())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([fetchedAt])
+  @@map("tv_season_bundles")
+}
+
+model RecommendationCache {
+  id        String    @id @default(uuid())
+  tmdbId    Int
+  mediaType MediaType
+  limit     Int
+  payload   Json // mapped recommendation list
+  fetchedAt DateTime  @default(now())
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  @@unique([tmdbId, mediaType, limit])
+  @@index([fetchedAt])
+  @@map("recommendation_cache")
 }
 
 enum ReviewStatus {

--- a/server/src/external-apis/external-apis.module.ts
+++ b/server/src/external-apis/external-apis.module.ts
@@ -3,11 +3,12 @@ import { HttpModule } from '@nestjs/axios';
 import { ConfigModule } from '@nestjs/config';
 import { TMDBService } from './services/tmdb.service';
 import { TmdbRateLimiterService } from './services/tmdb-rate-limiter.service';
+import { MediaCacheService } from './services/media-cache.service';
 
 @Global()
 @Module({
   imports: [HttpModule, ConfigModule],
-  providers: [TMDBService, TmdbRateLimiterService],
-  exports: [TMDBService, TmdbRateLimiterService],
+  providers: [TMDBService, TmdbRateLimiterService, MediaCacheService],
+  exports: [TMDBService, TmdbRateLimiterService, MediaCacheService],
 })
 export class ExternalApisModule {}

--- a/server/src/external-apis/services/media-cache.service.ts
+++ b/server/src/external-apis/services/media-cache.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RedisService } from 'src/redis/redis.service';
+
+/**
+ * Generic 3-layer read-through used for permanent-ish TMDB data
+ * (detail bundles, season bundles, recommendation lists):
+ *
+ *   Redis (hot L1) -> Postgres/Supabase (permanent L2) -> fetchFresh (TMDB)
+ *
+ * On an L2 hit that isn't stale, the value is served and Redis is re-warmed.
+ * On an L2 miss or stale row, fetchFresh runs and the result is written back to
+ * both layers. Cache writes never block the response — a Redis/Postgres failure
+ * is logged and the freshly fetched value is still returned.
+ */
+export interface ReadThroughOptions<T> {
+    redisKey: string;
+    redisTtlSeconds: number;
+    /** Look up the permanent row. Return null if absent. */
+    find: () => Promise<{ payload: T; fetchedAt: Date } | null>;
+    /** True when a found row is too old and should be refreshed. */
+    isStale: (fetchedAt: Date) => boolean;
+    /** Persist a freshly fetched payload to the permanent store. */
+    upsert: (payload: T) => Promise<void>;
+    /** Last-resort fetch (e.g. TMDB) when L1 + L2 miss or are stale. */
+    fetchFresh: () => Promise<T>;
+    /**
+     * Guard against persisting empty/failed results. Returns true when the
+     * freshly fetched value is worth caching. Defaults to always caching.
+     * (Recommendation fetchers swallow errors into [], so we skip caching those
+     * to avoid pinning a transient failure for the full TTL.)
+     */
+    shouldCache?: (result: T) => boolean;
+}
+
+@Injectable()
+export class MediaCacheService {
+    private readonly logger = new Logger(MediaCacheService.name);
+
+    constructor(private readonly redis: RedisService) {}
+
+    async readThrough<T>(opts: ReadThroughOptions<T>): Promise<T> {
+        // ── L1: Redis ──────────────────────────────────────────────
+        try {
+            const cached = await this.redis.get(opts.redisKey);
+            if (cached) return JSON.parse(cached) as T;
+        } catch (err) {
+            this.logger.warn(`Redis read failed for ${opts.redisKey}: ${(err as Error).message}`);
+        }
+
+        // ── L2: Postgres/Supabase ──────────────────────────────────
+        try {
+            const row = await opts.find();
+            if (row && !opts.isStale(row.fetchedAt)) {
+                void this.warmRedis(opts.redisKey, opts.redisTtlSeconds, row.payload);
+                return row.payload;
+            }
+        } catch (err) {
+            this.logger.warn(`L2 read failed for ${opts.redisKey}: ${(err as Error).message}`);
+        }
+
+        // ── L3: fetch fresh, then write back to both layers ────────
+        const fresh = await opts.fetchFresh();
+
+        if (!opts.shouldCache || opts.shouldCache(fresh)) {
+            void opts
+                .upsert(fresh)
+                .catch(err => this.logger.warn(`L2 write failed for ${opts.redisKey}: ${err?.message ?? err}`));
+            void this.warmRedis(opts.redisKey, opts.redisTtlSeconds, fresh);
+        }
+
+        return fresh;
+    }
+
+    private async warmRedis<T>(key: string, ttl: number, payload: T) {
+        try {
+            await this.redis.set(key, JSON.stringify(payload), ttl);
+        } catch (err) {
+            this.logger.warn(`Redis warm failed for ${key}: ${(err as Error).message}`);
+        }
+    }
+
+    /** Shared staleness helper: stale once older than maxAgeDays. */
+    static isOlderThanDays(fetchedAt: Date, maxAgeDays: number): boolean {
+        return Date.now() - new Date(fetchedAt).getTime() > maxAgeDays * 24 * 60 * 60 * 1000;
+    }
+}

--- a/server/src/jobs/seed.service.ts
+++ b/server/src/jobs/seed.service.ts
@@ -37,20 +37,29 @@ export class SeedService {
             ['genres:movie', () => this.tmdb.getMovieGenres()],
             ['genres:tv', () => this.tmdb.getTVGenres()],
 
-            // Movies homepage
+            // Movies homepage — every TMDB-heavy section it loads
             ['movies:trending', () => this.movies.getTrending(25)],
             ['movies:featured', () => this.movies.getFeatured(25)],
             ['movies:trailers', () => this.movies.getTrailers(25)],
             ['movies:upcoming-trailers', () => this.movies.getUpcomingTrailers(40)],
-            ['movies:korea', () => this.movies.getKoreaTrending(20)],
+            ['movies:korea', () => this.movies.getKoreaTrending(25)],
+            ['movies:action', () => this.movies.getActionMovies(20)],
+            ['movies:animated', () => this.movies.getAnimatedMovies(20)],
+            ['movies:indie', () => this.movies.getIndieMovies(20)],
+            ['movies:award-winners', () => this.movies.getAwardWinners(25)],
+            ['movies:new-releases', () => this.movies.getNewReleases(30)],
+            ['movies:favorites', () => this.movies.getFavorites(30)],
 
-            // TV homepage
+            // TV homepage — every TMDB-heavy section it loads
             ['tv:trending', () => this.tv.getTrending(25)],
             ['tv:featured', () => this.tv.getFeatured(20)],
             ['tv:trailers', () => this.tv.getTrailers(20)],
             ['tv:upcoming-trailers', () => this.tv.getUpcomingTrailers(60)],
             ['tv:korea', () => this.tv.getKoreaTrending(20)],
             ['tv:new-releases', () => this.tv.getNewReleases(30)],
+            ['tv:favorites', () => this.tv.getFavorites(30)],
+            ['tv:airing-today', () => this.tv.airingToday(15)],
+            ['tv:airing-week', () => this.tv.airingThisWeek(20)],
 
             // Default (/) homepage — the /all aggregate endpoints
             ['all:trending', () => this.all.getTrending(25)],

--- a/server/src/media/all/recommendations/recommendations.service.ts
+++ b/server/src/media/all/recommendations/recommendations.service.ts
@@ -1,9 +1,15 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { MediaType } from '@prisma/client';
 import { RedisService } from 'src/redis/redis.service';
 import { TmdbClientService } from '../client/tmdb-client.service';
 import { TmdbAll, Candidate, ScoredCandidate, TrailerCandidate } from '../types/tmdb.types';
 import { CACHE_TTL } from '../utils/helpers';
 import { runWithTmdbPriority, TMDB_PRIORITY } from 'src/external-apis/services/tmdb-priority.context';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { MediaCacheService } from 'src/external-apis/services/media-cache.service';
+
+const REC_REDIS_TTL = 6 * 60 * 60; // 6h hot L1
+const REC_STALE_DAYS = 1; // refresh recommendation list daily
 
 @Injectable()
 export class RecommendationsService {
@@ -12,24 +18,47 @@ export class RecommendationsService {
     constructor(
         private readonly client: TmdbClientService,
         private readonly redisService: RedisService,
+        private readonly prisma: PrismaService,
+        private readonly mediaCache: MediaCacheService,
     ) { }
 
+    // Read-through: Redis -> Supabase (recommendation_cache) -> compute.
     async getSmartRecommendations(
         type: 'movie' | 'tv',
         id: number,
         limit = 10,
         minRequired = 3
     ): Promise<TmdbAll[]> {
-        const cacheKey = `smart-rec-v2-${type}-${id}-${limit}`;
+        const mediaType = type === 'tv' ? MediaType.TV : MediaType.MOVIE;
+        return this.mediaCache.readThrough<TmdbAll[]>({
+            redisKey: `smart-rec-v2-${type}-${id}-${limit}`,
+            redisTtlSeconds: REC_REDIS_TTL,
+            find: async () => {
+                const row = await this.prisma.recommendationCache.findUnique({
+                    where: { tmdbId_mediaType_limit: { tmdbId: id, mediaType, limit } },
+                });
+                return row ? { payload: row.payload as any, fetchedAt: row.fetchedAt } : null;
+            },
+            isStale: (fetchedAt) => MediaCacheService.isOlderThanDays(fetchedAt, REC_STALE_DAYS),
+            upsert: async (payload) => {
+                const data = { tmdbId: id, mediaType, limit, payload: payload as any };
+                await this.prisma.recommendationCache.upsert({
+                    where: { tmdbId_mediaType_limit: { tmdbId: id, mediaType, limit } },
+                    create: data,
+                    update: { ...data, fetchedAt: new Date() },
+                });
+            },
+            shouldCache: (list) => Array.isArray(list) && list.length >= minRequired,
+            fetchFresh: () => this.computeSmartRecommendations(type, id, limit, minRequired),
+        });
+    }
 
-        const cached = await this.redisService.get(cacheKey);
-        if (cached) {
-            try {
-                const result = JSON.parse(cached) as TmdbAll[];
-                if (result.length >= minRequired) return result;
-            } catch { }
-        }
-
+    private async computeSmartRecommendations(
+        type: 'movie' | 'tv',
+        id: number,
+        limit = 10,
+        minRequired = 3
+    ): Promise<TmdbAll[]> {
         if (!this.client.token) return [];
 
         try {
@@ -220,7 +249,6 @@ export class RecommendationsService {
                 type,
             }));
 
-            await this.redisService.set(cacheKey, JSON.stringify(final), CACHE_TTL.RECOMMENDATIONS);
             return final;
         } catch (err) {
             this.logger.error(`getSmartRecommendations failed for ${type}/${id}`, err);

--- a/server/src/media/movies/details/movie-details.service.ts
+++ b/server/src/media/movies/details/movie-details.service.ts
@@ -1,11 +1,52 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { MediaType } from '@prisma/client';
 import { MovieTmdbClientService } from '../client/movie-tmdb-client.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { MediaCacheService } from 'src/external-apis/services/media-cache.service';
+
+const DETAIL_REDIS_TTL = 6 * 60 * 60; // 6h hot L1
+const DETAIL_STALE_DAYS = 30; // permanent L2 refresh window
 
 @Injectable()
 export class MovieDetailsService {
     private readonly logger = new Logger(MovieDetailsService.name);
 
-    constructor(private readonly client: MovieTmdbClientService) { }
+    constructor(
+        private readonly client: MovieTmdbClientService,
+        private readonly prisma: PrismaService,
+        private readonly mediaCache: MediaCacheService,
+    ) { }
+
+    // Read-through: Redis -> Supabase (media_details) -> TMDB. The assembled
+    // bundle is the same shape consumers already expect; only the source varies.
+    async movieDetails(id: number) {
+        return this.mediaCache.readThrough({
+            redisKey: `detail:movie:${id}`,
+            redisTtlSeconds: DETAIL_REDIS_TTL,
+            find: async () => {
+                const row = await this.prisma.mediaDetail.findUnique({
+                    where: { tmdbId_mediaType: { tmdbId: id, mediaType: MediaType.MOVIE } },
+                });
+                return row ? { payload: row.payload as any, fetchedAt: row.fetchedAt } : null;
+            },
+            isStale: (fetchedAt) => MediaCacheService.isOlderThanDays(fetchedAt, DETAIL_STALE_DAYS),
+            upsert: async (payload: any) => {
+                const data = {
+                    tmdbId: id,
+                    mediaType: MediaType.MOVIE,
+                    title: payload?.info?.title ?? 'Untitled',
+                    popularity: payload?.info?.popularity ?? null,
+                    payload,
+                };
+                await this.prisma.mediaDetail.upsert({
+                    where: { tmdbId_mediaType: { tmdbId: id, mediaType: MediaType.MOVIE } },
+                    create: data,
+                    update: { ...data, fetchedAt: new Date() },
+                });
+            },
+            fetchFresh: () => this.assembleMovieDetails(id),
+        });
+    }
 
     // Bundles credits, videos and release_dates into the single /movie/{id}
     // request via append_to_response. similar + reviews are intentionally NOT
@@ -59,7 +100,7 @@ export class MovieDetailsService {
         return 'NR';
     }
 
-    async movieDetails(id: number) {
+    private async assembleMovieDetails(id: number) {
         const [infoRaw, providersRaw] = await Promise.all([
             this.fetchInfo(id),
             this.fetchProviders(id),

--- a/server/src/media/movies/recommendations/movie-recommendations.service.ts
+++ b/server/src/media/movies/recommendations/movie-recommendations.service.ts
@@ -1,13 +1,23 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { MediaType } from '@prisma/client';
 import { MovieTmdbClientService } from '../client/movie-tmdb-client.service';
 import { TmdbMovie } from '../types/movie.types';
 import { runWithTmdbPriority, TMDB_PRIORITY } from 'src/external-apis/services/tmdb-priority.context';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { MediaCacheService } from 'src/external-apis/services/media-cache.service';
+
+const REC_REDIS_TTL = 6 * 60 * 60; // 6h hot L1
+const REC_STALE_DAYS = 1; // refresh recommendation list daily
 
 @Injectable()
 export class MovieRecommendationsService {
     private readonly logger = new Logger(MovieRecommendationsService.name);
 
-    constructor(private readonly client: MovieTmdbClientService) { }
+    constructor(
+        private readonly client: MovieTmdbClientService,
+        private readonly prisma: PrismaService,
+        private readonly mediaCache: MediaCacheService,
+    ) { }
 
     scoreCandidates(
         candidates: any[],
@@ -53,7 +63,37 @@ export class MovieRecommendationsService {
         return scored;
     }
 
+    // Read-through: Redis -> Supabase (recommendation_cache) -> compute. Empty
+    // results are not cached (transient TMDB failures surface as []).
     async getSmartRecommendationsMovie(
+        id: number,
+        limit = 10,
+        minRequired = 3,
+    ): Promise<TmdbMovie[]> {
+        return this.mediaCache.readThrough<TmdbMovie[]>({
+            redisKey: `rec:movie:${id}:${limit}`,
+            redisTtlSeconds: REC_REDIS_TTL,
+            find: async () => {
+                const row = await this.prisma.recommendationCache.findUnique({
+                    where: { tmdbId_mediaType_limit: { tmdbId: id, mediaType: MediaType.MOVIE, limit } },
+                });
+                return row ? { payload: row.payload as any, fetchedAt: row.fetchedAt } : null;
+            },
+            isStale: (fetchedAt) => MediaCacheService.isOlderThanDays(fetchedAt, REC_STALE_DAYS),
+            upsert: async (payload) => {
+                const data = { tmdbId: id, mediaType: MediaType.MOVIE, limit, payload: payload as any };
+                await this.prisma.recommendationCache.upsert({
+                    where: { tmdbId_mediaType_limit: { tmdbId: id, mediaType: MediaType.MOVIE, limit } },
+                    create: data,
+                    update: { ...data, fetchedAt: new Date() },
+                });
+            },
+            shouldCache: (list) => Array.isArray(list) && list.length > 0,
+            fetchFresh: () => this.computeSmartRecommendationsMovie(id, limit, minRequired),
+        });
+    }
+
+    private async computeSmartRecommendationsMovie(
         id: number,
         limit = 10,
         minRequired = 3,

--- a/server/src/media/tv/details/tv-details.service.ts
+++ b/server/src/media/tv/details/tv-details.service.ts
@@ -1,11 +1,53 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { MediaType } from '@prisma/client';
 import { TvTmdbClientService } from '../client/tv-tmdb-client.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { MediaCacheService } from 'src/external-apis/services/media-cache.service';
+
+const DETAIL_REDIS_TTL = 6 * 60 * 60; // 6h hot L1
+const DETAIL_STALE_DAYS = 30; // permanent L2 refresh window
+const SEASONS_REDIS_TTL = 6 * 60 * 60; // 6h hot L1
+const SEASONS_STALE_DAYS = 7; // refresh weekly so airing shows pick up new episodes
 
 @Injectable()
 export class TvDetailsService {
     private readonly logger = new Logger(TvDetailsService.name);
 
-    constructor(private readonly client: TvTmdbClientService) { }
+    constructor(
+        private readonly client: TvTmdbClientService,
+        private readonly prisma: PrismaService,
+        private readonly mediaCache: MediaCacheService,
+    ) { }
+
+    // Read-through: Redis -> Supabase (media_details) -> TMDB.
+    async tvDetails(id: number) {
+        return this.mediaCache.readThrough({
+            redisKey: `detail:tv:${id}`,
+            redisTtlSeconds: DETAIL_REDIS_TTL,
+            find: async () => {
+                const row = await this.prisma.mediaDetail.findUnique({
+                    where: { tmdbId_mediaType: { tmdbId: id, mediaType: MediaType.TV } },
+                });
+                return row ? { payload: row.payload as any, fetchedAt: row.fetchedAt } : null;
+            },
+            isStale: (fetchedAt) => MediaCacheService.isOlderThanDays(fetchedAt, DETAIL_STALE_DAYS),
+            upsert: async (payload: any) => {
+                const data = {
+                    tmdbId: id,
+                    mediaType: MediaType.TV,
+                    title: payload?.info?.title ?? 'Untitled',
+                    popularity: payload?.info?.popularity ?? null,
+                    payload,
+                };
+                await this.prisma.mediaDetail.upsert({
+                    where: { tmdbId_mediaType: { tmdbId: id, mediaType: MediaType.TV } },
+                    create: data,
+                    update: { ...data, fetchedAt: new Date() },
+                });
+            },
+            fetchFresh: () => this.assembleTvDetails(id),
+        });
+    }
 
     // Bundles aggregate_credits, videos and content_ratings into the single
     // /tv/{id} request via append_to_response. similar + reviews are
@@ -93,7 +135,7 @@ export class TvDetailsService {
         return 'NR';
     }
 
-    async tvDetails(id: number) {
+    private async assembleTvDetails(id: number) {
         const [infoRaw, providersRaw] = await Promise.all([
             this.fetchInfo(id),
             this.fetchProviders(id),
@@ -173,7 +215,37 @@ export class TvDetailsService {
         };
     }
 
+    // Read-through: Redis -> Supabase (tv_season_bundles) -> TMDB. Only the full
+    // (with-episodes) variant is cached in the bundle table — the lightweight
+    // variant bypasses it since the table is keyed by tmdbId only.
     async fetchSeasonsWithEpisodes(
+        id: number,
+        options: { includeEpisodeDetails?: boolean } = { includeEpisodeDetails: true },
+    ) {
+        if (!options.includeEpisodeDetails) {
+            return this.assembleSeasonsWithEpisodes(id, options);
+        }
+        return this.mediaCache.readThrough<any>({
+            redisKey: `seasons:tv:${id}`,
+            redisTtlSeconds: SEASONS_REDIS_TTL,
+            find: async () => {
+                const row = await this.prisma.tvSeasonBundle.findUnique({ where: { tmdbId: id } });
+                return row ? { payload: row.payload as any, fetchedAt: row.fetchedAt } : null;
+            },
+            isStale: (fetchedAt) => MediaCacheService.isOlderThanDays(fetchedAt, SEASONS_STALE_DAYS),
+            upsert: async (payload) => {
+                await this.prisma.tvSeasonBundle.upsert({
+                    where: { tmdbId: id },
+                    create: { tmdbId: id, payload },
+                    update: { payload, fetchedAt: new Date() },
+                });
+            },
+            shouldCache: (seasons) => Array.isArray(seasons) && seasons.length > 0,
+            fetchFresh: () => this.assembleSeasonsWithEpisodes(id, options),
+        });
+    }
+
+    private async assembleSeasonsWithEpisodes(
         id: number,
         options: { includeEpisodeDetails?: boolean } = { includeEpisodeDetails: true },
     ) {

--- a/server/src/media/tv/recommendations/tv-recommendations.service.ts
+++ b/server/src/media/tv/recommendations/tv-recommendations.service.ts
@@ -1,13 +1,23 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { MediaType } from '@prisma/client';
 import { TvTmdbClientService } from '../client/tv-tmdb-client.service';
 import { TmdbTv } from '../types/tv.types';
 import { runWithTmdbPriority, TMDB_PRIORITY } from 'src/external-apis/services/tmdb-priority.context';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { MediaCacheService } from 'src/external-apis/services/media-cache.service';
+
+const REC_REDIS_TTL = 6 * 60 * 60; // 6h hot L1
+const REC_STALE_DAYS = 1; // refresh recommendation list daily
 
 @Injectable()
 export class TvRecommendationsService {
     private readonly logger = new Logger(TvRecommendationsService.name);
 
-    constructor(private readonly client: TvTmdbClientService) { }
+    constructor(
+        private readonly client: TvTmdbClientService,
+        private readonly prisma: PrismaService,
+        private readonly mediaCache: MediaCacheService,
+    ) { }
 
     private scoreCandidates(
         candidates: any[],
@@ -53,7 +63,32 @@ export class TvRecommendationsService {
         return scored;
     }
 
+    // Read-through: Redis -> Supabase (recommendation_cache) -> compute.
     async getSmartRecommendationsTv(id: number, limit = 10, minRequired = 3): Promise<TmdbTv[]> {
+        return this.mediaCache.readThrough<TmdbTv[]>({
+            redisKey: `rec:tv:${id}:${limit}`,
+            redisTtlSeconds: REC_REDIS_TTL,
+            find: async () => {
+                const row = await this.prisma.recommendationCache.findUnique({
+                    where: { tmdbId_mediaType_limit: { tmdbId: id, mediaType: MediaType.TV, limit } },
+                });
+                return row ? { payload: row.payload as any, fetchedAt: row.fetchedAt } : null;
+            },
+            isStale: (fetchedAt) => MediaCacheService.isOlderThanDays(fetchedAt, REC_STALE_DAYS),
+            upsert: async (payload) => {
+                const data = { tmdbId: id, mediaType: MediaType.TV, limit, payload: payload as any };
+                await this.prisma.recommendationCache.upsert({
+                    where: { tmdbId_mediaType_limit: { tmdbId: id, mediaType: MediaType.TV, limit } },
+                    create: data,
+                    update: { ...data, fetchedAt: new Date() },
+                });
+            },
+            shouldCache: (list) => Array.isArray(list) && list.length > 0,
+            fetchFresh: () => this.computeSmartRecommendationsTv(id, limit, minRequired),
+        });
+    }
+
+    private async computeSmartRecommendationsTv(id: number, limit = 10, minRequired = 3): Promise<TmdbTv[]> {
         try {
             const baseItem = await this.client.tmdb(`tv/${id}?language=en-US`);
             if (!baseItem) return [];


### PR DESCRIPTION
Add a Redis(L1) -> Supabase(L2) -> TMDB read-through so detail, recommendation and season data survive Redis eviction instead of re-hitting TMDB.

- New MediaCacheService.readThrough (Redis -> Postgres -> fetch, write-back, shouldCache guard so empty/failed results aren't persisted)
- New Prisma models: MediaDetail, RecommendationCache, TvSeasonBundle
- Wire movie/tv detail bundles, movie/tv/all recommendations, and TV seasons through the read-through (staleness: details 30d, recs 24h, seasons 7d)
- Trim cached detail payload: drop unused similar/reviews/raw + exclude /images from cache (~halves Redis usage)
- Drop legacy unused tables: Movie, Series, content_cache
- Expand 3 AM seed to pre-warm all movie/tv homepage endpoints