### PR TITLE
perf(server): Phase 3 — Redis rate limiting, email-verification hygie…

### DIFF
--- a/server/prisma/migrations/20260621080804_reconcile_drop_badge_add_email_indexes/migration.sql
+++ b/server/prisma/migrations/20260621080804_reconcile_drop_badge_add_email_indexes/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Reconciliation migration (written idempotently on purpose).
+
+  - Drops the unused legacy `Badge` table. It was already removed on production
+    out-of-band, which caused migrate-history drift; `IF EXISTS` makes this a safe
+    no-op there while still dropping it on fresh/dev databases. CASCADE clears its
+    own FK (Badge_userId_fkey).
+  - Adds the EmailVerification indexes. `IF NOT EXISTS` keeps this safe if the
+    indexes were already created manually on production.
+*/
+
+-- DropTable (idempotent)
+DROP TABLE IF EXISTS "Badge" CASCADE;
+
+-- CreateIndex (idempotent)
+CREATE INDEX IF NOT EXISTS "EmailVerification_email_code_idx" ON "EmailVerification"("email", "code");
+
+-- CreateIndex (idempotent)
+CREATE INDEX IF NOT EXISTS "EmailVerification_expiresAt_idx" ON "EmailVerification"("expiresAt");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -37,7 +37,6 @@ model User {
   discloseRecentActivity Boolean   @default(true)
   createdAt          DateTime      @default(now())
   Quiz               Quiz[]
-  Badge              Badge[]
   Watchlist          Watchlist[]
   LikedList          LikedList?
   reviews            Review[]
@@ -52,6 +51,11 @@ model EmailVerification {
   expiresAt DateTime
   verified  Boolean  @default(false)
   createdAt DateTime @default(now())
+
+  // Lookups filter by email(+code); the cleanup job filters by expiresAt. Without
+  // these every verify/request was a full table scan that worsened as rows piled up.
+  @@index([email, code])
+  @@index([expiresAt])
 }
 
 model Quiz {
@@ -61,14 +65,6 @@ model Quiz {
   answers    Json
   resultMood String
   createdAt  DateTime @default(now())
-}
-
-model Badge {
-  id        String   @id @default(uuid())
-  userId    String
-  user      User     @relation(fields: [userId], references: [id])
-  badgeType String
-  awardedAt DateTime @default(now())
 }
 
 model Achievement {

--- a/server/src/common/guards/rate-limit.guard.ts
+++ b/server/src/common/guards/rate-limit.guard.ts
@@ -5,11 +5,7 @@ import {
   HttpStatus,
   Injectable,
 } from '@nestjs/common';
-
-interface RateLimitBucket {
-  count: number;
-  resetAt: number;
-}
+import { RedisService } from 'src/redis/redis.service';
 
 interface RateLimitRule {
   points: number;
@@ -43,27 +39,34 @@ const SENSITIVE_AUTH_PATHS = [
 
 @Injectable()
 export class RateLimitGuard implements CanActivate {
-  private readonly buckets = new Map<string, RateLimitBucket>();
-  private lastPruneAt = Date.now();
+  constructor(private readonly redis: RedisService) {}
 
-  canActivate(context: ExecutionContext): boolean {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
     const response = context.switchToHttp().getResponse();
-    const now = Date.now();
     const path = this.getPath(request);
     const rule = this.getRule(path);
-    const key = `${this.getClientKey(request)}:${request.method}:${path}`;
-    const bucket = this.getBucket(key, rule, now);
+    const key = `rl:${this.getClientKey(request)}:${request.method}:${path}`;
 
-    bucket.count += 1;
-    const remaining = Math.max(0, rule.points - bucket.count);
-    const resetSeconds = Math.ceil((bucket.resetAt - now) / 1000);
+    let count: number;
+    let ttlMs: number;
+    try {
+      ({ count, ttlMs } = await this.redis.rateLimitHit(key, rule.windowMs));
+    } catch (err) {
+      // Fail open: a Redis outage must never take the whole API down. We'd rather
+      // briefly skip rate limiting than 500 every request.
+      console.error('[rate-limit] Redis unavailable, allowing request:', err);
+      return true;
+    }
+
+    const remaining = Math.max(0, rule.points - count);
+    const resetSeconds = Math.ceil((ttlMs > 0 ? ttlMs : rule.windowMs) / 1000);
 
     response.setHeader('RateLimit-Limit', String(rule.points));
     response.setHeader('RateLimit-Remaining', String(remaining));
     response.setHeader('RateLimit-Reset', String(resetSeconds));
 
-    if (bucket.count > rule.points) {
+    if (count > rule.points) {
       response.setHeader('Retry-After', String(resetSeconds));
       throw new HttpException(
         'Too many requests. Please wait a moment and try again.',
@@ -71,17 +74,7 @@ export class RateLimitGuard implements CanActivate {
       );
     }
 
-    this.pruneExpiredBuckets(now);
     return true;
-  }
-
-  private getBucket(key: string, rule: RateLimitRule, now: number): RateLimitBucket {
-    const current = this.buckets.get(key);
-    if (current && current.resetAt > now) return current;
-
-    const next = { count: 0, resetAt: now + rule.windowMs };
-    this.buckets.set(key, next);
-    return next;
   }
 
   private getRule(path: string): RateLimitRule {
@@ -107,15 +100,5 @@ export class RateLimitGuard implements CanActivate {
 
   private getPath(request: any): string {
     return request.originalUrl?.split('?')[0] ?? request.url?.split('?')[0] ?? '/';
-  }
-
-  private pruneExpiredBuckets(now: number): void {
-    if (now - this.lastPruneAt < 60_000) return;
-
-    for (const [key, bucket] of this.buckets.entries()) {
-      if (bucket.resetAt <= now) this.buckets.delete(key);
-    }
-
-    this.lastPruneAt = now;
   }
 }

--- a/server/src/jobs/email-verification-cleanup.service.ts
+++ b/server/src/jobs/email-verification-cleanup.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+/**
+ * Password-reset codes are short-lived but were never deleted, so the
+ * EmailVerification table grew unbounded. Purge expired rows hourly. Expiry
+ * covers every stale state: unverified-expired, and verified rows (the reset flow
+ * flips `verified` back to false and they expire within minutes).
+ */
+@Injectable()
+export class EmailVerificationCleanupService {
+  private readonly logger = new Logger('EmailVerificationCleanup');
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async purgeExpired() {
+    try {
+      const { count } = await this.prisma.emailVerification.deleteMany({
+        where: { expiresAt: { lt: new Date() } },
+      });
+      if (count > 0) {
+        this.logger.log(`Purged ${count} expired email verification codes`);
+      }
+    } catch (err) {
+      this.logger.error('Failed to purge expired email verification codes', err);
+    }
+  }
+}

--- a/server/src/jobs/jobs.module.ts
+++ b/server/src/jobs/jobs.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { SeedService } from './seed.service';
+import { EmailVerificationCleanupService } from './email-verification-cleanup.service';
 import { MoviesModule } from 'src/media/movies/movies.module';
 import { TvModule } from 'src/media/tv/tv.module';
 import { AllModule } from 'src/media/all/all.module';
 
 @Module({
   imports: [MoviesModule, TvModule, AllModule],
-  providers: [SeedService],
+  providers: [SeedService, EmailVerificationCleanupService],
 })
 export class JobsModule {}

--- a/server/src/redis/redis.service.ts
+++ b/server/src/redis/redis.service.ts
@@ -45,6 +45,30 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     await this.client.del(key);
   }
 
+  /**
+   * Atomic fixed-window rate-limit hit: increment the counter, set the window TTL
+   * on the first hit, and return the current count + remaining TTL — one round
+   * trip via a Lua script so concurrent requests can't race the expiry. Works
+   * across instances, which an in-process counter cannot.
+   */
+  async rateLimitHit(
+    key: string,
+    windowMs: number,
+  ): Promise<{ count: number; ttlMs: number }> {
+    const script = `
+      local count = redis.call('INCR', KEYS[1])
+      if count == 1 then
+        redis.call('PEXPIRE', KEYS[1], ARGV[1])
+      end
+      return { count, redis.call('PTTL', KEYS[1]) }
+    `;
+    const result = (await this.client.eval(script, {
+      keys: [key],
+      arguments: [String(windowMs)],
+    })) as [number, number];
+    return { count: result[0], ttlMs: result[1] };
+  }
+
   async getOrSet<T>(
     key: string,
     ttlSeconds: number,


### PR DESCRIPTION
…ne, drift reconcile

- 3a: move rate limiting from an in-process Map to Redis (atomic INCR+PEXPIRE via Lua), so limits work across instances and survive deploys; fails open if Redis is unavailable.
- 3b: index EmailVerification (email,code) and (expiresAt); add an hourly cron that purges expired codes so the table stops growing unbounded.
- Reconcile schema drift: remove the unused legacy  model/table (it was dropped on prod out-of-band and is referenced nowhere in code). Migration is idempotent (DROP TABLE IF EXISTS / CREATE INDEX IF NOT EXISTS) so it safely no-ops against prod's existing state.