### PR TITLE
perf: cache discovery carousels (Redis) + timeout-harden SSG fetches

### DIFF
--- a/client/app/movies/page.tsx
+++ b/client/app/movies/page.tsx
@@ -27,12 +27,18 @@ type DbCriticReview = {
 };
 
 async function fetchWithFallback<T>(endpoint: string, fallback: T): Promise<T> {
+  // Hard timeout so a slow/down backend can't hang static generation past Next's
+  // 60s page-build limit — a hiccup degrades the section to its fallback instead
+  // of failing the whole deploy.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
   try {
     const res = await fetch(`${BASE_URL}${endpoint}`, {
       next: { revalidate: 60 },
       headers: {
         "Content-Type": "application/json",
       },
+      signal: controller.signal,
     });
 
     if (!res.ok) {
@@ -45,12 +51,17 @@ async function fetchWithFallback<T>(endpoint: string, fallback: T): Promise<T> {
   } catch (error) {
     console.error(`Error fetching ${endpoint}:`, error);
     return fallback;
+  } finally {
+    clearTimeout(timer);
   }
 }
 async function fetchMoods() {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
   try {
     const res = await fetch(`${BASE_URL}/moods`, {
       next: { revalidate: 3600 }, // Cache for 1 hour
+      signal: controller.signal,
     });
 
     if (!res.ok) {
@@ -62,6 +73,8 @@ async function fetchMoods() {
   } catch (error) {
     console.error("Error fetching moods:", error);
     return [];
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/client/app/tv/page.tsx
+++ b/client/app/tv/page.tsx
@@ -27,12 +27,18 @@ type DbCriticReview = {
 
 // Fetch functions with error handling
 async function fetchWithFallback<T>(endpoint: string, fallback: T): Promise<T> {
+  // Hard timeout so a slow/down backend can't hang static generation past Next's
+  // 60s page-build limit — a hiccup degrades the section to its fallback instead
+  // of failing the whole deploy.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
   try {
     const res = await fetch(`${BASE_URL}${endpoint}`, {
       next: { revalidate: 60 },
       headers: {
         "Content-Type": "application/json",
       },
+      signal: controller.signal,
     });
 
     if (!res.ok) {
@@ -45,13 +51,18 @@ async function fetchWithFallback<T>(endpoint: string, fallback: T): Promise<T> {
   } catch (error) {
     console.error(`Error fetching ${endpoint}:`, error);
     return fallback;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
 async function fetchMoods() {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
   try {
     const res = await fetch(`${BASE_URL}/moods`, {
       next: { revalidate: 3600 }, // Cache for 1 hour
+      signal: controller.signal,
     });
 
     if (!res.ok) {
@@ -63,6 +74,8 @@ async function fetchMoods() {
   } catch (error) {
     console.error("Error fetching moods:", error);
     return [];
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/server/src/routes/review/review.service.ts
+++ b/server/src/routes/review/review.service.ts
@@ -18,6 +18,12 @@ import {
   ReviewWithRepliesEntity,
 } from './entities';
 import { TmdbClientService } from 'src/media/all/client/tmdb-client.service';
+import { RedisService } from 'src/redis/redis.service';
+
+// Short cache for the public discovery carousels (critics corner / community
+// picks). They previously hit the DB — plus per-item TMDB fallbacks — on every
+// request; a 2-minute cache collapses that to one build per window.
+const CRITICS_CORNER_TTL = 120; // seconds
 
 @Injectable()
 export class ReviewService {
@@ -28,6 +34,7 @@ export class ReviewService {
     private moderationDecision: ModerationDecisionService,
     private userService: UserService,
     private tmdbClient: TmdbClientService,
+    private redis: RedisService,
   ) {}
 
   async createReview(userId: string, dto: CreateReviewDto) {
@@ -219,6 +226,15 @@ export class ReviewService {
 
   async getMovieCriticsCorner(limit = 6) {
     const safeLimit = Math.max(1, Math.min(Number(limit) || 6, 24));
+    return this.redis.getOrSet(
+      `reviews:critics-corner:movies:${safeLimit}`,
+      CRITICS_CORNER_TTL,
+      () => this.buildMovieCriticsCorner(safeLimit),
+      (r) => Array.isArray(r) && r.length > 0,
+    );
+  }
+
+  private async buildMovieCriticsCorner(safeLimit: number) {
     const poolSize = Math.max(safeLimit * 4, 24);
 
     const reviews = await this.prisma.review.findMany({
@@ -306,6 +322,15 @@ export class ReviewService {
 
   async getTVCriticsCorner(limit = 6) {
     const safeLimit = Math.max(1, Math.min(Number(limit) || 6, 24));
+    return this.redis.getOrSet(
+      `reviews:critics-corner:tv:${safeLimit}`,
+      CRITICS_CORNER_TTL,
+      () => this.buildTVCriticsCorner(safeLimit),
+      (r) => Array.isArray(r) && r.length > 0,
+    );
+  }
+
+  private async buildTVCriticsCorner(safeLimit: number) {
     const poolSize = Math.max(safeLimit * 4, 24);
 
     const reviews = await this.prisma.review.findMany({
@@ -395,6 +420,15 @@ export class ReviewService {
 
   async getCommunityPicks(limit = 18) {
     const safeLimit = Math.max(1, Math.min(Number(limit) || 18, 36));
+    return this.redis.getOrSet(
+      `reviews:community-picks:${safeLimit}`,
+      CRITICS_CORNER_TTL,
+      () => this.buildCommunityPicks(safeLimit),
+      (r) => Array.isArray(r) && r.length > 0,
+    );
+  }
+
+  private async buildCommunityPicks(safeLimit: number) {
     const poolSize = Math.max(safeLimit * 4, 36);
 
     const reviews = await this.prisma.review.findMany({


### PR DESCRIPTION
- 3d: serve critics-corner (movie/tv) and community-picks from a 120s Redis getOrSet instead of hitting the DB + per-item TMDB fallbacks every request.
- 3e: add an 8s AbortController timeout to the movies/tv server-component fetchers so a slow/down backend degrades sections to their fallback rather than blowing Next's 60s static-generation limit and failing the deploy.