### PR TITLE
perf: normalize watchlist/liked into join tables (3c)

### DIFF
--- a/server/prisma/migrations/20260621084422_add_watchlist_liked_items/migration.sql
+++ b/server/prisma/migrations/20260621084422_add_watchlist_liked_items/migration.sql
@@ -1,0 +1,67 @@
+-- CreateTable
+CREATE TABLE "watchlist_items" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tmdbId" INTEGER NOT NULL,
+    "mediaType" "MediaType" NOT NULL,
+    "addedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "watchlist_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "liked_items" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tmdbId" INTEGER NOT NULL,
+    "mediaType" "MediaType" NOT NULL,
+    "addedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "liked_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "watchlist_items_userId_addedAt_idx" ON "watchlist_items"("userId", "addedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "watchlist_items_userId_tmdbId_mediaType_key" ON "watchlist_items"("userId", "tmdbId", "mediaType");
+
+-- CreateIndex
+CREATE INDEX "liked_items_userId_addedAt_idx" ON "liked_items"("userId", "addedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "liked_items_userId_tmdbId_mediaType_key" ON "liked_items"("userId", "tmdbId", "mediaType");
+
+-- AddForeignKey
+ALTER TABLE "watchlist_items" ADD CONSTRAINT "watchlist_items_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "liked_items" ADD CONSTRAINT "liked_items_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Backfill: copy existing saved/liked titles from the legacy array columns into the
+-- normalized tables. Idempotent (ON CONFLICT DO NOTHING) and guards against any
+-- non-numeric ids, so it is safe to re-run and a no-op once applied. The legacy
+-- Watchlist/LikedList tables are left intact (dropped in a later cleanup migration).
+INSERT INTO "watchlist_items" ("id", "userId", "tmdbId", "mediaType", "addedAt")
+SELECT gen_random_uuid(), w."userId", t.tmdb::int, 'MOVIE'::"MediaType", w."addedAt"
+FROM "Watchlist" w, unnest(w."movieId") AS t(tmdb)
+WHERE t.tmdb ~ '^[0-9]+$'
+ON CONFLICT ("userId", "tmdbId", "mediaType") DO NOTHING;
+
+INSERT INTO "watchlist_items" ("id", "userId", "tmdbId", "mediaType", "addedAt")
+SELECT gen_random_uuid(), w."userId", t.tmdb::int, 'TV'::"MediaType", w."addedAt"
+FROM "Watchlist" w, unnest(w."seriesId") AS t(tmdb)
+WHERE t.tmdb ~ '^[0-9]+$'
+ON CONFLICT ("userId", "tmdbId", "mediaType") DO NOTHING;
+
+INSERT INTO "liked_items" ("id", "userId", "tmdbId", "mediaType", "addedAt")
+SELECT gen_random_uuid(), l."userId", t.tmdb::int, 'MOVIE'::"MediaType", l."addedAt"
+FROM "LikedList" l, unnest(l."movieId") AS t(tmdb)
+WHERE t.tmdb ~ '^[0-9]+$'
+ON CONFLICT ("userId", "tmdbId", "mediaType") DO NOTHING;
+
+INSERT INTO "liked_items" ("id", "userId", "tmdbId", "mediaType", "addedAt")
+SELECT gen_random_uuid(), l."userId", t.tmdb::int, 'TV'::"MediaType", l."addedAt"
+FROM "LikedList" l, unnest(l."seriesId") AS t(tmdb)
+WHERE t.tmdb ~ '^[0-9]+$'
+ON CONFLICT ("userId", "tmdbId", "mediaType") DO NOTHING;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -39,6 +39,8 @@ model User {
   Quiz               Quiz[]
   Watchlist          Watchlist[]
   LikedList          LikedList?
+  watchlistItems     WatchlistItem[]
+  likedItems         LikedItem[]
   reviews            Review[]
   reviewReplies      ReviewReply[]
   userAchievements   UserAchievement[]
@@ -151,6 +153,36 @@ model LikedList {
   movieId  String[] @default([])
   seriesId String[] @default([])
   addedAt  DateTime @default(now())
+}
+
+// Normalized replacements for the Watchlist/LikedList array columns: one row per
+// saved/liked title so membership is an indexed point lookup, writes don't rewrite
+// a whole array, and the list can be paginated. The legacy array tables above are
+// kept until data is backfilled and verified, then dropped in a follow-up.
+model WatchlistItem {
+  id        String    @id @default(uuid())
+  userId    String
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tmdbId    Int
+  mediaType MediaType
+  addedAt   DateTime  @default(now())
+
+  @@unique([userId, tmdbId, mediaType])
+  @@index([userId, addedAt])
+  @@map("watchlist_items")
+}
+
+model LikedItem {
+  id        String    @id @default(uuid())
+  userId    String
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tmdbId    Int
+  mediaType MediaType
+  addedAt   DateTime  @default(now())
+
+  @@unique([userId, tmdbId, mediaType])
+  @@index([userId, addedAt])
+  @@map("liked_items")
 }
 
 model Review {

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -269,8 +269,8 @@ export class AuthService {
       distinctMoodRows,
       moodTotal,
       reviewCount,
-      watchlist,
-      liked,
+      savedCount,
+      likedCount,
       quizCount,
       unlockedCount,
       existingProgressRows,
@@ -298,16 +298,14 @@ export class AuthService {
       }),
       this.prismaService.mood.count({ where: { isActive: true } }),
       this.prismaService.review.count({ where: { userId } }),
-      this.prismaService.watchlist.findUnique({ where: { userId } }),
-      this.prismaService.likedList.findUnique({ where: { userId } }),
+      this.prismaService.watchlistItem.count({ where: { userId } }),
+      this.prismaService.likedItem.count({ where: { userId } }),
       this.prismaService.quiz.count({ where: { userId } }),
       this.prismaService.userAchievement.count({ where: { userId, unlocked: true } }),
       this.prismaService.userAchievement.findMany({ where: { userId } }),
     ]);
 
     const distinctMoods = distinctMoodRows.length;
-    const savedCount = (watchlist?.movieId.length ?? 0) + (watchlist?.seriesId.length ?? 0);
-    const likedCount = (liked?.movieId.length ?? 0) + (liked?.seriesId.length ?? 0);
     const profileBasic = user?.name && user?.username ? 1 : 0;
     const profileStyled =
       user?.avatarUrl && (user.preferredGenres.length > 0 || user.preferredLanguages.length > 0) ? 1 : 0;

--- a/server/src/liked/liked.service.ts
+++ b/server/src/liked/liked.service.ts
@@ -5,106 +5,81 @@ import { PrismaService } from '../prisma/prisma.service';
 
 type Kind = 'movie' | 'series';
 
-type ToggleRow = { added: boolean; movieId: string[]; seriesId: string[] };
-
 @Injectable()
 export class LikedService {
   constructor(private prisma: PrismaService) {}
 
-  private async ensureLikedList(userId: string) {
-    try {
-      return await this.prisma.likedList.upsert({
-        where: { userId },
-        update: {},
-        create: {
-          user: { connect: { id: userId } },
-          movieId: [],
-          seriesId: [],
-        },
-      });
-    } catch (e) {
-      // Two concurrent first-time ensures can race the upsert to a P2002;
-      // the row exists now, so just read it back.
-      if (e instanceof PrismaClientKnownRequestError && e.code === 'P2002') {
-        const existing = await this.prisma.likedList.findUnique({ where: { userId } });
-        if (existing) return existing;
-      }
-      throw e;
-    }
-  }
-
   /**
-   * Get liked list. Read-only — never creates a row. Creating on read meant every
-   * concurrent reader (common right after login) raced to INSERT the same row,
-   * producing a P2002 unique-constraint error per loser. The row is created lazily
-   * on the first write (toggle/remove both call ensureLikedList first).
+   * Get the liked list as { movieId, seriesId } string-id arrays, preserving the
+   * legacy response shape. One indexed query over normalized rows.
    */
   async getAll(userId: string) {
-    const likedList = await this.prisma.likedList.findUnique({ where: { userId } });
-    return likedList ?? { userId, movieId: [], seriesId: [] };
+    const items = await this.prisma.likedItem.findMany({
+      where: { userId },
+      select: { tmdbId: true, mediaType: true },
+    });
+    const movieId: string[] = [];
+    const seriesId: string[] = [];
+    for (const item of items) {
+      (item.mediaType === MediaType.MOVIE ? movieId : seriesId).push(String(item.tmdbId));
+    }
+    return { userId, movieId, seriesId };
   }
 
+  /** Toggle a title in/out of the liked list — a single-row insert or delete. */
   async toggle(userId: string, tmdbId: string, type: Kind) {
-    await this.ensureLikedList(userId);
-
-    const field = type === 'movie' ? 'movieId' : 'seriesId';
     const mediaType = type === 'movie' ? MediaType.MOVIE : MediaType.TV;
     const numericId = Number(tmdbId);
 
     return this.prisma.$transaction(async (tx) => {
-      // Add-or-remove happens inside the DB under a row lock, so concurrent
-      // toggles serialize on the row and can't lose updates. RETURNING reports
-      // the post-update state, so `added` is the real transition — not a stale read.
-      const rows = await tx.$queryRawUnsafe<ToggleRow[]>(
-        `UPDATE "LikedList"
-            SET "${field}" = CASE WHEN $1 = ANY("${field}")
-                                  THEN array_remove("${field}", $1)
-                                  ELSE array_append("${field}", $1) END
-          WHERE "userId" = $2
-          RETURNING ($1 = ANY("${field}")) AS "added", "movieId", "seriesId"`,
-        tmdbId,
-        userId,
-      );
-
-      const row = rows[0];
-      const added = !!row?.added;
-
-      // Counter delta matches the actual DB transition, so it can't drift.
-      await tx.mediaStat.upsert({
-        where: { tmdbId_mediaType: { tmdbId: numericId, mediaType } },
-        create: { tmdbId: numericId, mediaType, likeCount: added ? 1 : 0 },
-        update: { likeCount: { increment: added ? 1 : -1 } },
+      const existing = await tx.likedItem.findUnique({
+        where: { userId_tmdbId_mediaType: { userId, tmdbId: numericId, mediaType } },
+        select: { id: true },
       });
 
-      return {
-        liked: added,
-        totalMovies: row?.movieId.length ?? 0,
-        totalSeries: row?.seriesId.length ?? 0,
-      };
+      let delta = 0;
+      if (existing) {
+        const { count } = await tx.likedItem.deleteMany({
+          where: { userId, tmdbId: numericId, mediaType },
+        });
+        delta = count > 0 ? -1 : 0;
+      } else {
+        try {
+          await tx.likedItem.create({ data: { userId, tmdbId: numericId, mediaType } });
+          delta = 1;
+        } catch (e) {
+          // Lost the add race to a concurrent toggle — the row exists now, no net change.
+          if (!(e instanceof PrismaClientKnownRequestError && e.code === 'P2002')) throw e;
+        }
+      }
+
+      if (delta !== 0) {
+        await tx.mediaStat.upsert({
+          where: { tmdbId_mediaType: { tmdbId: numericId, mediaType } },
+          create: { tmdbId: numericId, mediaType, likeCount: delta > 0 ? 1 : 0 },
+          update: { likeCount: { increment: delta } },
+        });
+      }
+
+      const [totalMovies, totalSeries] = await Promise.all([
+        tx.likedItem.count({ where: { userId, mediaType: MediaType.MOVIE } }),
+        tx.likedItem.count({ where: { userId, mediaType: MediaType.TV } }),
+      ]);
+
+      return { liked: !existing, totalMovies, totalSeries };
     });
   }
 
   async remove(userId: string, type: 'movie' | 'tv', tmdbId: number) {
-    await this.ensureLikedList(userId);
-
-    const field = type === 'movie' ? 'movieId' : 'seriesId';
     const mediaType = type === 'movie' ? MediaType.MOVIE : MediaType.TV;
-    const idStr = String(tmdbId);
     const label = type === 'movie' ? 'Movie' : 'Series';
 
     return this.prisma.$transaction(async (tx) => {
-      // Only updates (and only returns a row) when the id was actually present,
-      // so the counter is decremented exactly once and never for a no-op.
-      const rows = await tx.$queryRawUnsafe<{ userId: string }[]>(
-        `UPDATE "LikedList"
-            SET "${field}" = array_remove("${field}", $1)
-          WHERE "userId" = $2 AND $1 = ANY("${field}")
-          RETURNING "userId"`,
-        idStr,
-        userId,
-      );
+      const { count } = await tx.likedItem.deleteMany({
+        where: { userId, tmdbId, mediaType },
+      });
 
-      if (rows.length === 0) {
+      if (count === 0) {
         return { message: `${label} ${tmdbId} was not liked` };
       }
 

--- a/server/src/routes/review/review.service.ts
+++ b/server/src/routes/review/review.service.ts
@@ -677,19 +677,11 @@ export class ReviewService {
         discloseLiked: true,
         discloseBadges: true,
         discloseRecentActivity: true,
-        Watchlist: {
-          select: {
-            movieId: true,
-            seriesId: true,
-            addedAt: true,
-          },
+        watchlistItems: {
+          select: { tmdbId: true, mediaType: true, addedAt: true },
         },
-        LikedList: {
-          select: {
-            movieId: true,
-            seriesId: true,
-            addedAt: true,
-          },
+        likedItems: {
+          select: { tmdbId: true, mediaType: true, addedAt: true },
         },
         userAchievements: {
           where: { unlocked: true },
@@ -722,11 +714,25 @@ export class ReviewService {
       avatarUrl: disclosure.profileInfo ? user.avatarUrl : null,
       createdAt: disclosure.profileInfo ? user.createdAt : null,
     };
+    // Aggregate the normalized item rows back into the { movieId, seriesId } shape
+    // the rest of this method (and the response) expects; addedAt = most recent.
+    const aggregateItems = (
+      items: { tmdbId: number; mediaType: MediaType; addedAt: Date }[],
+    ) => {
+      const movieId: string[] = [];
+      const seriesId: string[] = [];
+      let addedAt: Date | null = null;
+      for (const item of items) {
+        (item.mediaType === MediaType.MOVIE ? movieId : seriesId).push(String(item.tmdbId));
+        if (!addedAt || item.addedAt > addedAt) addedAt = item.addedAt;
+      }
+      return { movieId, seriesId, addedAt };
+    };
     const watchlist = disclosure.watchlist
-      ? (user.Watchlist[0] ?? { movieId: [], seriesId: [], addedAt: null })
+      ? aggregateItems(user.watchlistItems)
       : { movieId: [], seriesId: [], addedAt: null };
     const liked = disclosure.liked
-      ? (user.LikedList ?? { movieId: [], seriesId: [], addedAt: null })
+      ? aggregateItems(user.likedItems)
       : { movieId: [], seriesId: [], addedAt: null };
     const achievements = disclosure.badges
       ? user.userAchievements.map((progress) => ({

--- a/server/src/watchlist/watchlist.service.ts
+++ b/server/src/watchlist/watchlist.service.ts
@@ -4,102 +4,92 @@ import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { PrismaService } from '../prisma/prisma.service';
 
 type Kind = 'movie' | 'series';
-type Field = 'movieId' | 'seriesId';
-
-type ToggleRow = { added: boolean; movieId: string[]; seriesId: string[] };
 
 @Injectable()
 export class WatchlistService {
-  constructor(private prisma: PrismaService) { }
-
-  /** Ensure the user has exactly one watchlist row (upsert avoids a find→create race). */
-  private async ensureWatchlist(userId: string) {
-    try {
-      return await this.prisma.watchlist.upsert({
-        where: { userId },
-        update: {},
-        create: {
-          user: { connect: { id: userId } },
-          movieId: [],
-          seriesId: [],
-        },
-      });
-    } catch (e) {
-      // Two concurrent first-time ensures can race the upsert to a P2002;
-      // the row exists now, so just read it back.
-      if (e instanceof PrismaClientKnownRequestError && e.code === 'P2002') {
-        const existing = await this.prisma.watchlist.findUnique({ where: { userId } });
-        if (existing) return existing;
-      }
-      throw e;
-    }
-  }
+  constructor(private prisma: PrismaService) {}
 
   /**
-   * Get watchlist. Read-only — never creates a row. Creating on read meant every
-   * concurrent reader (common right after login) raced to INSERT the same row,
-   * producing a P2002 unique-constraint error per loser. The row is created lazily
-   * on the first write (toggle/remove/clear all call ensureWatchlist first).
+   * Get the watchlist as { movieId, seriesId } string-id arrays, preserving the
+   * legacy response shape so the client is unaffected. Now one indexed query over
+   * normalized rows instead of loading a per-user array column.
    */
   async getAll(userId: string) {
-    const watchlist = await this.prisma.watchlist.findUnique({ where: { userId } });
-    return watchlist ?? { userId, movieId: [], seriesId: [] };
+    const items = await this.prisma.watchlistItem.findMany({
+      where: { userId },
+      select: { tmdbId: true, mediaType: true },
+    });
+    const movieId: string[] = [];
+    const seriesId: string[] = [];
+    for (const item of items) {
+      (item.mediaType === MediaType.MOVIE ? movieId : seriesId).push(String(item.tmdbId));
+    }
+    return { userId, movieId, seriesId };
   }
 
-  /** Toggle add/remove tmdbId into the correct array column */
+  /** Toggle a title in/out of the watchlist — a single-row insert or delete. */
   async toggle(userId: string, tmdbId: string, type: Kind) {
-    await this.ensureWatchlist(userId);
-
-    const field: Field = type === 'movie' ? 'movieId' : 'seriesId';
     const mediaType = type === 'movie' ? MediaType.MOVIE : MediaType.TV;
     const numericId = Number(tmdbId);
 
     return this.prisma.$transaction(async (tx) => {
-      // Add-or-remove happens inside the DB under a row lock, so concurrent
-      // toggles serialize on the row and can't lose updates. RETURNING reports
-      // the post-update state, so `added` is the real transition — not a stale read.
-      const rows = await tx.$queryRawUnsafe<ToggleRow[]>(
-        `UPDATE "Watchlist"
-            SET "${field}" = CASE WHEN $1 = ANY("${field}")
-                                  THEN array_remove("${field}", $1)
-                                  ELSE array_append("${field}", $1) END
-          WHERE "userId" = $2
-          RETURNING ($1 = ANY("${field}")) AS "added", "movieId", "seriesId"`,
-        tmdbId,
-        userId,
-      );
-
-      const row = rows[0];
-      const added = !!row?.added;
-
-      // Counter delta matches the actual DB transition, so it can't drift.
-      await tx.mediaStat.upsert({
-        where: { tmdbId_mediaType: { tmdbId: numericId, mediaType } },
-        create: { tmdbId: numericId, mediaType, savedCount: added ? 1 : 0 },
-        update: { savedCount: { increment: added ? 1 : -1 } },
+      const existing = await tx.watchlistItem.findUnique({
+        where: { userId_tmdbId_mediaType: { userId, tmdbId: numericId, mediaType } },
+        select: { id: true },
       });
 
-      return {
-        removed: !added,
-        totalMovies: row?.movieId.length ?? 0,
-        totalSeries: row?.seriesId.length ?? 0,
-      };
+      // delta drives the counter and reflects the *actual* transition, so it can't
+      // drift even under a concurrent toggle of the same title.
+      let delta = 0;
+      if (existing) {
+        const { count } = await tx.watchlistItem.deleteMany({
+          where: { userId, tmdbId: numericId, mediaType },
+        });
+        delta = count > 0 ? -1 : 0;
+      } else {
+        try {
+          await tx.watchlistItem.create({ data: { userId, tmdbId: numericId, mediaType } });
+          delta = 1;
+        } catch (e) {
+          // Lost the add race to a concurrent toggle — the row exists now, no net change.
+          if (!(e instanceof PrismaClientKnownRequestError && e.code === 'P2002')) throw e;
+        }
+      }
+
+      if (delta !== 0) {
+        await tx.mediaStat.upsert({
+          where: { tmdbId_mediaType: { tmdbId: numericId, mediaType } },
+          create: { tmdbId: numericId, mediaType, savedCount: delta > 0 ? 1 : 0 },
+          update: { savedCount: { increment: delta } },
+        });
+      }
+
+      const [totalMovies, totalSeries] = await Promise.all([
+        tx.watchlistItem.count({ where: { userId, mediaType: MediaType.MOVIE } }),
+        tx.watchlistItem.count({ where: { userId, mediaType: MediaType.TV } }),
+      ]);
+
+      return { removed: !!existing, totalMovies, totalSeries };
     });
   }
 
-  /** Optional clear-all */
+  /** Clear the entire watchlist. */
   async clear(userId: string) {
-    await this.ensureWatchlist(userId);
-
     return this.prisma.$transaction(async (tx) => {
-      // Lock the row so concurrent toggles wait, then read the ids we're about to drop.
-      const rows = await tx.$queryRawUnsafe<{ movieId: string[]; seriesId: string[] }[]>(
-        `SELECT "movieId", "seriesId" FROM "Watchlist" WHERE "userId" = $1 FOR UPDATE`,
-        userId,
-      );
-      const cur = rows[0] ?? { movieId: [], seriesId: [] };
-      const movieIds = cur.movieId.map(Number).filter((n) => !Number.isNaN(n));
-      const seriesIds = cur.seriesId.map(Number).filter((n) => !Number.isNaN(n));
+      const items = await tx.watchlistItem.findMany({
+        where: { userId },
+        select: { tmdbId: true, mediaType: true },
+      });
+      if (items.length === 0) return { movieId: [], seriesId: [] };
+
+      const movieIds = items
+        .filter((i) => i.mediaType === MediaType.MOVIE)
+        .map((i) => i.tmdbId);
+      const seriesIds = items
+        .filter((i) => i.mediaType === MediaType.TV)
+        .map((i) => i.tmdbId);
+
+      await tx.watchlistItem.deleteMany({ where: { userId } });
 
       if (movieIds.length) {
         await tx.mediaStat.updateMany({
@@ -114,38 +104,22 @@ export class WatchlistService {
         });
       }
 
-      return tx.watchlist.update({
-        where: { userId },
-        data: { movieId: [], seriesId: [] },
-      });
+      return { movieId: [], seriesId: [] };
     });
   }
 
-  async removeFromWatchlist(
-    userId: string,
-    type: 'movie' | 'tv',
-    tmdbId: number,
-  ) {
-    await this.ensureWatchlist(userId);
-
-    const field: Field = type === 'movie' ? 'movieId' : 'seriesId';
+  async removeFromWatchlist(userId: string, type: 'movie' | 'tv', tmdbId: number) {
     const mediaType = type === 'movie' ? MediaType.MOVIE : MediaType.TV;
-    const idStr = String(tmdbId);
     const label = type === 'movie' ? 'Movie' : 'Series';
 
     return this.prisma.$transaction(async (tx) => {
-      // Only updates (and only returns a row) when the id was actually present,
-      // so the counter is decremented exactly once and never for a no-op.
-      const rows = await tx.$queryRawUnsafe<{ userId: string }[]>(
-        `UPDATE "Watchlist"
-            SET "${field}" = array_remove("${field}", $1)
-          WHERE "userId" = $2 AND $1 = ANY("${field}")
-          RETURNING "userId"`,
-        idStr,
-        userId,
-      );
+      // deleteMany returns the count, so the counter decrements exactly once and
+      // never for a no-op.
+      const { count } = await tx.watchlistItem.deleteMany({
+        where: { userId, tmdbId, mediaType },
+      });
 
-      if (rows.length === 0) {
+      if (count === 0) {
         return { message: `${label} ${tmdbId} was not in watchlist` };
       }
 


### PR DESCRIPTION
Replace the per-user array columns (Watchlist.movieId/seriesId, LikedList.*) with one-row-per-title tables (watchlist_items, liked_items): membership is an indexed point lookup, toggles are single-row inserts/deletes (no whole-array rewrite, no single-row contention), and lists are paginatable.

- New WatchlistItem/LikedItem models + unique(userId,tmdbId,mediaType).
- Rewrote watchlist/liked services (response shapes unchanged → client untouched).
- Migrated all other readers: achievement counts (auth.service) and the public profile (review.service) now read the new tables.
- Idempotent data backfill (unnest arrays, ON CONFLICT DO NOTHING). Legacy tables kept for now; dropped in a follow-up once verified.