### PR TITLE
perf: cache achievement progress + move avatars to object storage (3g)

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -25,6 +25,11 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'lh3.googleusercontent.com',
       },
+      {
+        // Supabase Storage public URLs for user avatars.
+        protocol: 'https',
+        hostname: '**.supabase.co',
+      },
     ],
   },
   reactStrictMode: true,

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -69,6 +69,11 @@ import { AppService } from './app.service';
         // mailer throws a clear error at send time if RESEND_API_KEY is missing.
         RESEND_API_KEY: Joi.string().empty('').optional(),
         MAIL_FROM: Joi.string().empty('').optional(),
+        // Avatar object storage (Supabase Storage). Optional so boot never depends
+        // on them; the avatar endpoint errors clearly at use if unset.
+        SUPABASE_URL: Joi.string().empty('').optional(),
+        SUPABASE_SERVICE_ROLE_KEY: Joi.string().empty('').optional(),
+        AVATAR_BUCKET: Joi.string().empty('').optional(),
       }),
       validationOptions: { allowUnknown: true, abortEarly: false },
     }),

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -20,6 +20,7 @@ import { v4 as uuid } from 'uuid';
 import { randomBytes, randomInt } from 'node:crypto';
 import { RedisService } from 'src/redis/redis.service';
 import { sendVerificationCode } from '../utils/mailer';
+import { uploadAvatarToStorage } from '../utils/storage';
 import { REFRESH_TTL_SECONDS } from './auth.cookies';
 
 
@@ -262,6 +263,18 @@ export class AuthService {
   }
 
   async getAchievementProgress(userId: string) {
+    // ~11 queries + a write per call; cache briefly so repeated reads of the
+    // achievements page don't recompute every time. Progress is eventually
+    // consistent within the TTL (it persists on each cache miss).
+    return this.redis.getOrSet(
+      `achievements:${userId}`,
+      60, // seconds
+      () => this.computeAchievementProgress(userId),
+      (rows) => Array.isArray(rows) && rows.length > 0,
+    );
+  }
+
+  private async computeAchievementProgress(userId: string) {
     const [
       achievements,
       user,
@@ -599,9 +612,15 @@ export class AuthService {
       throw new BadRequestException('Image too large. Please upload a smaller image.');
     }
 
+    // Base64 uploads go to object storage; we persist only the resulting URL so the
+    // User row (returned on every /auth/me) stays small instead of carrying ~200KB.
+    const finalUrl = isBase64
+      ? await uploadAvatarToStorage(avatarUrl, userId)
+      : avatarUrl;
+
     return this.prismaService.user.update({
       where: { id: String(userId) },
-      data: { avatarUrl },
+      data: { avatarUrl: finalUrl },
       select: { id: true, avatarUrl: true },
     });
   }

--- a/server/src/utils/storage.ts
+++ b/server/src/utils/storage.ts
@@ -1,0 +1,67 @@
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+
+const SUPABASE_URL = process.env.SUPABASE_URL?.replace(/\/$/, '');
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const AVATAR_BUCKET = process.env.AVATAR_BUCKET || 'avatars';
+
+const EXT_BY_TYPE: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+};
+
+/**
+ * Upload a base64 image data URL to Supabase Storage and return its public URL.
+ * Avatars used to be stored as base64 directly on the User row (~200KB returned
+ * on every /auth/me); this keeps only a small URL in the DB. Uses the Storage
+ * REST API over HTTPS (no extra dependency); the service-role key is server-only.
+ */
+export async function uploadAvatarToStorage(
+  dataUrl: string,
+  userId: string,
+): Promise<string> {
+  if (!SUPABASE_URL || !SERVICE_KEY) {
+    throw new InternalServerErrorException(
+      'Avatar storage is not configured (set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY).',
+    );
+  }
+
+  const match = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/s.exec(dataUrl);
+  if (!match) throw new BadRequestException('Invalid image data URL');
+  const contentType = match[1];
+  const ext = EXT_BY_TYPE[contentType];
+  if (!ext) throw new BadRequestException('Unsupported image type');
+  const buffer = Buffer.from(match[2], 'base64');
+
+  // Deterministic path per user + upsert, so a new avatar overwrites the old one
+  // (no orphaned files to clean up).
+  const path = `${userId}.${ext}`;
+  const uploadUrl = `${SUPABASE_URL}/storage/v1/object/${AVATAR_BUCKET}/${path}`;
+
+  const res = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SERVICE_KEY}`,
+      'Content-Type': contentType,
+      'x-upsert': 'true',
+      'cache-control': '3600',
+    },
+    body: new Uint8Array(buffer),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new InternalServerErrorException(
+      `Avatar upload failed (${res.status}): ${detail}`,
+    );
+  }
+
+  // Public URL (bucket must be public-read). Cache-bust with a version param so
+  // the browser fetches the new image after an upsert to the same path.
+  return `${SUPABASE_URL}/storage/v1/object/public/${AVATAR_BUCKET}/${path}?v=${Date.now()}`;
+}


### PR DESCRIPTION
- 3g(a): serve getAchievementProgress from a 60s per-user Redis cache so the ~11-query recompute runs at most once/minute, not on every read.
- 3g(b): upload base64 avatars to Supabase Storage and persist only the URL, so the User row (returned on every /auth/me) no longer carries ~200KB. Needs SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY + an  bucket.