### PR TITLE
fix: apply same pop up design in reviews.tsx to allreviews.tsx

### DIFF
--- a/client/components/selected-content/extended/allReviews.tsx
+++ b/client/components/selected-content/extended/allReviews.tsx
@@ -1160,7 +1160,7 @@ export default function AllReviews({
                   aria-modal="true"
                   aria-labelledby="review-dialog-title"
                   aria-describedby="review-dialog-description"
-                  className="relative flex h-[100dvh] w-full max-w-2xl flex-col overflow-hidden border border-white/10 bg-[#0a0a0b]/96 shadow-2xl shadow-black/70 sm:h-auto sm:max-h-[min(90dvh,780px)] sm:rounded-2xl"
+                  className="relative flex max-h-[calc(100dvh-env(safe-area-inset-top)-0.5rem)] w-full max-w-2xl flex-col overflow-hidden rounded-t-2xl border border-white/10 bg-[#0a0a0b]/96 shadow-2xl shadow-black/70 sm:max-h-[min(90dvh,780px)] sm:rounded-2xl"
                   style={{
                     boxShadow:
                       "0 32px 90px rgba(0,0,0,0.72), 0 0 0 1px rgba(255,255,255,0.04)",


### PR DESCRIPTION
## Summary

- applied the same pop up design from reviews.tsx to allReviews.tsx

## Verification

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`

## Security / Env Notes

- [x] No secrets or real `.env` values committed
- [x] New env vars are documented in `.env.example`
- [x] Auth, cookie, CORS, rate-limit, token, or Prisma changes include manual test notes
